### PR TITLE
Fix GHA badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docker image of httping
 
 [![GitHub Super-Linter](https://github.com/bretfisher/httping-docker/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)
-![Build and Push Image](https://github.com/bretfisher/httping-docker/actions/workflows/docker-build-and-push.yaml/badge.svg?branch=main)
+![Build and Push Image](https://github.com/bretfisher/httping-docker/actions/workflows/call-docker-build.yaml/badge.svg?branch=main)
 
 This container image is stored on docker hub: [bretfisher/httping](https://hub.docker.com/r/bretfisher/httping/) and in this GitHub repositories packages.
 


### PR DESCRIPTION
Only fixing status badge rendering after renaming GH action.

P.S.: Just in case, the original project is still maintained on GH by the author - https://github.com/folkertvanheusden/HTTPing.